### PR TITLE
feat: add pricing/costs for gpt-5-codex

### DIFF
--- a/gateway/src/costs/openai.yaml
+++ b/gateway/src/costs/openai.yaml
@@ -18,6 +18,10 @@ models:
     input: 1.25
     cached_input: 0.125
     output: 10.00
+  gpt-5-codex:
+    input: 1.25
+    cached_input: 0.125
+    output: 10.00
 
   gpt-4.1:
     input: 2.00


### PR DESCRIPTION
Codex CLI now uses gpt-5-codex models as defaults in latest versions
- add pricing info for gpt-5-codex